### PR TITLE
Sync with 4.2.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,6 +137,7 @@ jobs:
         with:
           name: wheel-${{ matrix.wheel }}
           path: ./wheelhouse/*.whl
+          delete-merged: true
 
   merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
       #     done
       #     popd
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./wheelhouse/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
-    needs: upload
+    needs: build_wheels
     steps:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
             arch: arm64
     steps:
       - name: Download sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source
       - name: Unpack sdist
@@ -144,11 +144,11 @@ jobs:
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: source
           path: dist
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheels
           path: dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,6 @@ jobs:
         with:
           name: wheel-${{ matrix.wheel }}
           path: ./wheelhouse/*.whl
-          delete-merged: true
 
   merge:
     runs-on: ubuntu-latest
@@ -148,6 +147,7 @@ jobs:
         with:
           name: wheels
           pattern: wheel-*
+          delete-merged: true
 
   upload_pypi:
     needs: [build_wheels, build_src]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
       rel0: ${{ steps.query.outputs.rel0 }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Query PyPI for recent PySide release number
@@ -21,7 +21,7 @@ jobs:
           python -m pip install --user build
           python -m build --sdist
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: source
           path: dist/*.tar.gz
@@ -82,7 +82,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         with:
           output-dir: wheelhouse
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.runs-on }}
           path: ./wheelhouse/*.whl
 
   upload_pypi:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,8 +135,18 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.runs-on }}
+          name: wheel-${{ matrix.os }}
           path: ./wheelhouse/*.whl
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: upload
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wheels
+          pattern: wheel-*
 
   upload_pypi:
     needs: [build_wheels, build_src]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}
+          name: wheel-${{ matrix.wheel }}
           path: ./wheelhouse/*.whl
 
   merge:

--- a/init.py
+++ b/init.py
@@ -4,63 +4,78 @@ if platform.system() == 'Windows':
 	import os, PySide6, shiboken6
 	with os.add_dll_directory(os.path.dirname(PySide6.__file__)), \
 	     os.add_dll_directory(os.path.dirname(shiboken6.__file__)):
-		from .PySide6QtAds import ads as _ads
+		from .PySide6QtAds import ads
 else:
 	# Runtime library dependencies resolved via rpath
-	from .PySide6QtAds import ads as _ads
+	from .PySide6QtAds import ads
 
 # DockWidgetArea
-DockWidgetArea = _ads.DockWidgetArea
-NoDockWidgetArea = _ads.NoDockWidgetArea
-LeftDockWidgetArea = _ads.LeftDockWidgetArea
-RightDockWidgetArea = _ads.RightDockWidgetArea
-TopDockWidgetArea = _ads.TopDockWidgetArea
-BottomDockWidgetArea = _ads.BottomDockWidgetArea
-CenterDockWidgetArea = _ads.CenterDockWidgetArea
-InvalidDockWidgetArea = _ads.InvalidDockWidgetArea
-OuterDockAreas = _ads.OuterDockAreas
-AllDockAreas = _ads.AllDockAreas
+DockWidgetArea = ads.DockWidgetArea
+NoDockWidgetArea = ads.NoDockWidgetArea
+LeftDockWidgetArea = ads.LeftDockWidgetArea
+RightDockWidgetArea = ads.RightDockWidgetArea
+TopDockWidgetArea = ads.TopDockWidgetArea
+BottomDockWidgetArea = ads.BottomDockWidgetArea
+CenterDockWidgetArea = ads.CenterDockWidgetArea
+InvalidDockWidgetArea = ads.InvalidDockWidgetArea
+OuterDockAreas = ads.OuterDockAreas
+AllDockAreas = ads.AllDockAreas
+
+# eTabIndex
+TabDefaultInsertIndex = ads.TabDefaultInsertIndex
+TabInvalidIndex = ads.TabInvalidIndex
+
+# SideBarLocation
+SideBarLeft = ads.SideBarLeft
+SideBarTop = ads.SideBarTop
+SideBarBottom = ads.SideBarBottom
+SideBarRight = ads.SideBarRight
+SideBarNone = ads.SideBarNone
 
 # eBitwiseOperator
-BitwiseAnd = _ads.BitwiseAnd
-BitwiseOr = _ads.BitwiseOr
+BitwiseAnd = ads.BitwiseAnd
+BitwiseOr = ads.BitwiseOr
 
 # eDragState
-DraggingInactive = _ads.DraggingInactive
-DraggingMousePressed = _ads.DraggingMousePressed
-DraggingTab = _ads.DraggingTab
-DraggingFloatingWidget = _ads.DraggingFloatingWidget
+DraggingInactive = ads.DraggingInactive
+DraggingMousePressed = ads.DraggingMousePressed
+DraggingTab = ads.DraggingTab
+DraggingFloatingWidget = ads.DraggingFloatingWidget
 
 # eIcon
-TabCloseIcon = _ads.TabCloseIcon
-DockAreaMenuIcon = _ads.DockAreaMenuIcon
-DockAreaUndockIcon = _ads.DockAreaUndockIcon
-DockAreaCloseIcon = _ads.DockAreaCloseIcon
-IconCount = _ads.IconCount
+TabCloseIcon = ads.TabCloseIcon
+AutoHideIcon = ads.AutoHideIcon
+DockAreaMenuIcon = ads.DockAreaMenuIcon
+DockAreaUndockIcon = ads.DockAreaUndockIcon
+DockAreaCloseIcon = ads.DockAreaCloseIcon
+DockAreaMinimizeIcon = ads.DockAreaMinimizeIcon
+IconCount = ads.IconCount
 
 # TitleBarButton
-TitleBarButtonTabsMenu = _ads.TitleBarButtonTabsMenu
-TitleBarButtonUndock = _ads.TitleBarButtonUndock
-TitleBarButtonClose = _ads.TitleBarButtonClose
+TitleBarButtonTabsMenu = ads.TitleBarButtonTabsMenu
+TitleBarButtonUndock = ads.TitleBarButtonUndock
+TitleBarButtonClose = ads.TitleBarButtonClose
+TitleBarButtonAutoHide = ads.TitleBarButtonAutoHide
+TitleBarButtonMinimize = ads.TitleBarButtonMinimize
 
 # Classes
-CDockAreaTabBar = _ads.CDockAreaTabBar
-CDockAreaTitleBar = _ads.CDockAreaTitleBar
-CDockAreaWidget = _ads.CDockAreaWidget
-CDockComponentsFactory = _ads.CDockComponentsFactory
-CDockContainerWidget = _ads.CDockContainerWidget
-CDockFocusController = _ads.CDockFocusController
-CDockManager = _ads.CDockManager
-CDockSplitter = _ads.CDockSplitter
-CDockOverlay = _ads.CDockOverlay
-CDockOverlayCross = _ads.CDockOverlayCross
-CDockWidget = _ads.CDockWidget
-CDockWidgetTab = _ads.CDockWidgetTab
-CDockingStateReader = _ads.CDockingStateReader
-CElidingLabel = _ads.CElidingLabel
-CFloatingDockContainer = _ads.CFloatingDockContainer
-CFloatingDragPreview = _ads.CFloatingDragPreview
-IFloatingWidget = _ads.IFloatingWidget
-CIconProvider = _ads.CIconProvider
-CSpacerWidget = _ads.CSpacerWidget
-CTitleBarButton = _ads.CTitleBarButton
+CDockAreaTabBar = ads.CDockAreaTabBar
+CDockAreaTitleBar = ads.CDockAreaTitleBar
+CDockAreaWidget = ads.CDockAreaWidget
+CDockComponentsFactory = ads.CDockComponentsFactory
+CDockContainerWidget = ads.CDockContainerWidget
+CDockFocusController = ads.CDockFocusController
+CDockManager = ads.CDockManager
+CDockSplitter = ads.CDockSplitter
+CDockOverlay = ads.CDockOverlay
+CDockOverlayCross = ads.CDockOverlayCross
+CDockWidget = ads.CDockWidget
+CDockWidgetTab = ads.CDockWidgetTab
+CDockingStateReader = ads.CDockingStateReader
+CElidingLabel = ads.CElidingLabel
+CFloatingDockContainer = ads.CFloatingDockContainer
+CFloatingDragPreview = ads.CFloatingDragPreview
+IFloatingWidget = ads.IFloatingWidget
+CIconProvider = ads.CIconProvider
+CSpacerWidget = ads.CSpacerWidget
+CTitleBarButton = ads.CTitleBarButton

--- a/scripts/custom-auditwheel.py
+++ b/scripts/custom-auditwheel.py
@@ -1,32 +1,40 @@
 #!/usr/bin/env python3
-import sys
-
+from pathlib import Path
+import tempfile
+import json
 from auditwheel.main import main
-from auditwheel.policy import _POLICIES as POLICIES
-
-
-for p in POLICIES:
-    p['lib_whitelist'].extend([
-        'libpyside6.abi3.so.6.6',
-        'libpyside6.abi3.so.6.5',
-        'libpyside6.abi3.so.6.4',
-        'libpyside6.abi3.so.6.3',
-        'libshiboken6.abi3.so.6.6',
-        'libshiboken6.abi3.so.6.5',
-        'libshiboken6.abi3.so.6.4',
-        'libshiboken6.abi3.so.6.3',
-        'libQt6Widgets.so.6',
-        'libQt6Gui.so.6',
-        'libpyside6qml.abi3.so.6.6',
-        'libpyside6qml.abi3.so.6.5',
-        'libpyside6qml.abi3.so.6.4',
-        'libpyside6qml.abi3.so.6.3',
-        'libGLX.so.0',
-        'libOpenGL.so.0',
-        'libQt6Core.so.6',
-        'libxcb.so.1',
-    ])
+from auditwheel.policy import _POLICY_JSON_MAP as POLICY_JSON_MAP
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    tmpdir = tempfile.TemporaryDirectory()
+    tmppath = pathlib.Path(tmpdir.name)
+    for libc in POLICY_JSON_MAP:
+        p = json.loads(POLICY_JSON_MAP[libc].read_text())
+        p['lib_whitelist'].extend([
+            'libpyside6.abi3.so.6.6',
+            'libpyside6.abi3.so.6.5',
+            'libpyside6.abi3.so.6.4',
+            'libpyside6.abi3.so.6.3',
+            'libshiboken6.abi3.so.6.6',
+            'libshiboken6.abi3.so.6.5',
+            'libshiboken6.abi3.so.6.4',
+            'libshiboken6.abi3.so.6.3',
+            'libQt6Widgets.so.6',
+            'libQt6Gui.so.6',
+            'libpyside6qml.abi3.so.6.6',
+            'libpyside6qml.abi3.so.6.5',
+            'libpyside6qml.abi3.so.6.4',
+            'libpyside6qml.abi3.so.6.3',
+            'libGLX.so.0',
+            'libOpenGL.so.0',
+            'libQt6Core.so.6',
+            'libxcb.so.1',
+        ])
+        fname = tmppath / libc.name + "-policy.json"
+        with open(fname, "w") as f:
+            json.dump(p, f)
+        POLICY_JSON_MAP[libc] = fname
+    
+    main()
+    tmpdir.cleanup()

--- a/scripts/custom-auditwheel.py
+++ b/scripts/custom-auditwheel.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
                 'libQt6Core.so.6',
                 'libxcb.so.1',
             ])
-        fname = tmppath / libc.name + "-policy.json"
+        fname = tmppath / (libc.name + "-policy.json")
         with open(fname, "w") as f:
             json.dump(policies, f)
         POLICY_JSON_MAP[libc] = fname

--- a/scripts/custom-auditwheel.py
+++ b/scripts/custom-auditwheel.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from pathlib import Path
+import pathlib
 import tempfile
 import json
 from auditwheel.main import main

--- a/scripts/custom-auditwheel.py
+++ b/scripts/custom-auditwheel.py
@@ -10,30 +10,31 @@ if __name__ == "__main__":
     tmpdir = tempfile.TemporaryDirectory()
     tmppath = pathlib.Path(tmpdir.name)
     for libc in POLICY_JSON_MAP:
-        p = json.loads(POLICY_JSON_MAP[libc].read_text())
-        p['lib_whitelist'].extend([
-            'libpyside6.abi3.so.6.6',
-            'libpyside6.abi3.so.6.5',
-            'libpyside6.abi3.so.6.4',
-            'libpyside6.abi3.so.6.3',
-            'libshiboken6.abi3.so.6.6',
-            'libshiboken6.abi3.so.6.5',
-            'libshiboken6.abi3.so.6.4',
-            'libshiboken6.abi3.so.6.3',
-            'libQt6Widgets.so.6',
-            'libQt6Gui.so.6',
-            'libpyside6qml.abi3.so.6.6',
-            'libpyside6qml.abi3.so.6.5',
-            'libpyside6qml.abi3.so.6.4',
-            'libpyside6qml.abi3.so.6.3',
-            'libGLX.so.0',
-            'libOpenGL.so.0',
-            'libQt6Core.so.6',
-            'libxcb.so.1',
-        ])
+        policies = json.loads(POLICY_JSON_MAP[libc].read_text())
+        for p in policies:
+            p['lib_whitelist'].extend([
+                'libpyside6.abi3.so.6.6',
+                'libpyside6.abi3.so.6.5',
+                'libpyside6.abi3.so.6.4',
+                'libpyside6.abi3.so.6.3',
+                'libshiboken6.abi3.so.6.6',
+                'libshiboken6.abi3.so.6.5',
+                'libshiboken6.abi3.so.6.4',
+                'libshiboken6.abi3.so.6.3',
+                'libQt6Widgets.so.6',
+                'libQt6Gui.so.6',
+                'libpyside6qml.abi3.so.6.6',
+                'libpyside6qml.abi3.so.6.5',
+                'libpyside6qml.abi3.so.6.4',
+                'libpyside6qml.abi3.so.6.3',
+                'libGLX.so.0',
+                'libOpenGL.so.0',
+                'libQt6Core.so.6',
+                'libxcb.so.1',
+            ])
         fname = tmppath / libc.name + "-policy.json"
         with open(fname, "w") as f:
-            json.dump(p, f)
+            json.dump(policies, f)
         POLICY_JSON_MAP[libc] = fname
     
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = PySide6-QtAds
-version = 4.1.0.4.dev0
+version = 4.2.1.dev0
 description = PySide6 bindings to Qt Advanced Docking System
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setuptools.setup(
             cmake_configure_options=[
                 "-DBUILD_EXAMPLES:BOOL=OFF",
                 "-DBUILD_STATIC:BOOL=ON",
-                "-DADS_VERSION=4.1.0",
+                "-DADS_VERSION=4.2.1",
                 f"-DPython3_ROOT_DIR={Path(sys.prefix)}"
             ],
             py_limited_api=True

--- a/src/bindings.xml
+++ b/src/bindings.xml
@@ -199,6 +199,7 @@
             <enum-type name="eAutoHideFlag" />
             <enum-type name="eViewMenuInsertionOrder" />
             <enum-type name="eConfigFlag" flags="ConfigFlags" />
+            <enum-type name="eAutoHideFlag" flags="AutoHideFlags" />
 
             <modify-function signature="registerFloatingWidget(ads::CFloatingDockContainer*)">
                 <modify-argument index="1">
@@ -239,6 +240,11 @@
                 </modify-argument>
             </modify-function>
             <modify-function signature="addAutoHideDockWidget(ads::SideBarLocation, ads::CDockWidget*)">
+                <modify-argument index="2">
+                    <parent index="this" action="add"/>
+                </modify-argument>
+            </modify-function>
+            <modify-function signature="addAutoHideDockWidgetToContainer(ads::SideBarLocation, ads::CDockWidget*, ads::CDockContainerWidget*)">
                 <modify-argument index="2">
                     <parent index="this" action="add"/>
                 </modify-argument>


### PR DESCRIPTION
Update to Qt-Advanced-Docking-System v4.2.1

This fixes #23 and #24 (_ads has to be renamed ads in init.py to get better error message when using wrong arguments of functions)

Also updated actions to remove deprecated node.js 16 warnings and updated cibuildwheel action to 2.16.5 because of pypa/cibuildwheel#1741. With `actions/upload-script` v4, artifacts are immutable, so a merge step is needed.

And updated custom-auditwheel script because `auditwheel.policy` does not have `_POLICIES` global anymore