### PR TITLE
Issue #34 Measure for RuntimeError exception of windowHandle()

### DIFF
--- a/src/bindings.xml
+++ b/src/bindings.xml
@@ -409,6 +409,7 @@
                     <parent index="this" action="add"/>
                 </modify-argument>
             </modify-function>
+            <declare-function signature="windowHandle()" return-type="QWindow"/>
         </object-type>
 
         <object-type name="CIconProvider">


### PR DESCRIPTION
Measure for following exception from QWindow.windowHandle()
```python
RuntimeError: Internal C++ object (PySide6.QtGui.QWindow) already deleted.
```