### PR TITLE
Update bindings to Qt ADS 5.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "PySide6-QtAds"
-version = "4.5.0.6.dev0"
+version = "5.0.0.0"
 description = "PySide6 bindings to Qt Advanced Docking System"
 license = { file = "LICENSE.txt" }
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setuptools.setup(
             cmake_configure_options=[
                 "-DBUILD_EXAMPLES:BOOL=OFF",
                 "-DBUILD_STATIC:BOOL=ON",
-                "-DADS_VERSION=4.5.0",
+                "-DADS_VERSION=5.0.0",
                 f"-DPython3_ROOT_DIR={Path(sys.prefix)}",
                 f"-DPython_EXECUTABLE={Path(sys.executable)}"
             ],

--- a/src/bindings.xml
+++ b/src/bindings.xml
@@ -200,6 +200,7 @@
             <enum-type name="eConfigFlag" flags="ConfigFlags" />
             <enum-type name="eAutoHideFlag" flags="AutoHideFlags" />
             <enum-type name="eConfigParam" flags="ConfigParam" />
+            <enum-type name="ColorSchemeMode" />
 
             <modify-function signature="registerFloatingWidget(ads::CFloatingDockContainer*)">
                 <modify-argument index="1">


### PR DESCRIPTION
Retarget the submodule to the Qt-Advanced-Docking-System v5.0.0 release and expose the new public API:

- Submodule: 87cffe5 (4.5.0-era) -> v5.0.0 (433b0c9). 5.0.0 includes native Wayland docking, dark mode, native-windows and stylesheet config flags, and per-widget preferred auto-hide sidebar location.
- src/bindings.xml: add the new CDockManager::ColorSchemeMode enum. All other new API (eConfigFlag UseNativeWindows/DisableStylesheet, setColorSchemeMode/isApplicationPaletteDark, CDockWidget preferred auto-hide location, CFloatingDockContainer Wayland statics) is auto-exposed by shiboken with no typesystem changes.
- setup.py: -DADS_VERSION 4.5.0 -> 5.0.0.
- pyproject.toml: version -> 5.0.0.0 (ADS 5.0.0 + binding patch .0).

No new top-level classes were added in 5.0.0, so bindings.h and the CMakeLists wrapper list are unchanged. Built an abi3 wheel and verified the new enum/flags/methods resolve and that dark mode + the docking lifecycle work; the Joulescope UI boots and restores its dock layout.

PR created as requested in https://github.com/mborgerson/pyside6_qtads/issues/103 .  Thanks @mborgerson !