### PR TITLE
ci: Don't vendor libxkbcommon in manylinux wheels

### DIFF
--- a/scripts/custom-auditwheel.py
+++ b/scripts/custom-auditwheel.py
@@ -46,6 +46,7 @@ if __name__ == "__main__":
                 'libOpenGL.so.0',
                 'libQt6Core.so.6',
                 'libxcb.so.1',
+                'libxkbcommon.so.0',
             ])
         fname = tmppath / (libc.name + "-policy.json")
         with open(fname, "w") as f:


### PR DESCRIPTION
Fixes #123.

Adds `libxkbcommon.so.0` to the auditwheel whitelist so it is no longer vendored into `pyside6_qtads.libs/`.

### Why

`libxkbcommon` gets grafted into the wheel and `$ORIGIN/../pyside6_qtads.libs` appended to `PySide6QtAds.so`'s RPATH. ELF has one flat library namespace per process, so `import PySide6QtAds` *before* `PySide6` lets the vendored copy claim the process-wide `libxkbcommon.so.0` slot. Qt's own Wayland input handling then silently reuses it, which segfaults on mouse motion under Wayland (full backtrace in #123). Import-sorting tools happily produce that ordering, so it's easy to hit by accident.

The dependency is entirely spurious. ADS is built static (`-DBUILD_STATIC:BOOL=ON`, setup.py#L88), so CMake records its `PRIVATE Qt6::GuiPrivate` link as `$<LINK_ONLY:…>` in the static lib's interface and propagates it to `PySide6QtAds.so`; `Qt6::GuiPrivate` carries Qt Gui's private platform deps, including `XKB::XKB`. Dumping undefined dynamic symbols from the released 5.0.0 wheel:

```
undefined 'xkb*' symbols in PySide6QtAds.so: NONE
undefined 'xcb*' symbols in PySide6QtAds.so: xcb_change_property, xcb_flush, xcb_get_atom_name,
    xcb_get_atom_name_name, xcb_get_atom_name_reply, xcb_get_property_reply,
    xcb_get_property_unchecked, xcb_get_property_value, xcb_get_property_value_length,
    xcb_get_setup, xcb_intern_atom, xcb_intern_atom_reply, xcb_send_event, xcb_setup_roots_iterator
```

`libxcb` is genuinely used (`ads_globals.cpp`); `libxkbcommon` is referenced by not a single symbol.

### Effect

Without the graft there is no second copy at all, so the load-order hazard disappears. `PySide6QtAds.so` keeps a plain `NEEDED libxkbcommon.so.0` resolved from the system — always present, since PySide6's own `libQt6Gui.so.6` links it directly. This is the same treatment already applied to `libxcb.so.1`, `libGLX.so.0` and `libQt6Gui.so.6`, and it covers the aarch64 job too since that path runs the same script.

`libxkbcommon-devel` should stay in `CIBW_BEFORE_BUILD_LINUX` — it's still needed for `find_package(Qt6 COMPONENTS GuiPrivate)` to succeed.

### When it regressed

Checked the published wheels rather than going by upload date:

| release | date | `pyside6_qtads.libs/` |
|---|---|---|
| 4.4.0.2 | 2025-07-28 | *(absent)* |
| 4.4.0.3 | 2025-09-02 | *(absent)* |
| **4.4.1** | **2025-09-20** | **`libxkbcommon-de59cad2.so.0.0.0`** |
| 4.4.1.1 → 5.0.0 | | `libxkbcommon-28342f8c.so.0.0.0` |

4.4.1 is the first affected release; the only build-relevant change in `v4.4.0.3..v4.4.1` is 6ea3fe2 "Update Qt-Advanced-Docking-System to 4.4.1", which is the submodule bump that added the `Qt6::GuiPrivate` link. Still present in ADS 5.0.0, so current `main` is affected.

### Alternative considered

Since zero xkbcommon symbols are used, building with `-Wl,--as-needed` would drop the `NEEDED` entry at the source (AlmaLinux's gcc doesn't default to it). Left out here to keep the diff minimal and reviewable — happy to follow up separately if preferred.

### Testing

Verified by inspection of the published wheels; I don't have a Linux build environment set up to produce a repaired wheel locally, so a CI run is the real check. @mliberty1 offered in #123 to review and test on Ubuntu 26.04 with the Joulescope UI.
